### PR TITLE
Update version to 0.2.0

### DIFF
--- a/msg/PrismaticConfig.msg
+++ b/msg/PrismaticConfig.msg
@@ -14,4 +14,4 @@ float64[] parameters
 # Configuration type
 uint8 type
 
-uint8 TYPE_SET_P = 1
+uint8 TYPE_SET_PID = 1

--- a/msg/PrismaticState.msg
+++ b/msg/PrismaticState.msg
@@ -7,3 +7,4 @@ float32 position
 
 # Controller state
 float32 set_point
+float32 error

--- a/msg/RevoluteState.msg
+++ b/msg/RevoluteState.msg
@@ -13,6 +13,7 @@ float32 temperature
 
 # Controller state
 float32 set_point
+float32 error
 
 # Joint status:
 uint8 status

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
 	<name>dyret_common</name>
-	<version>0.1.0</version>
+	<version>0.2.0</version>
 	<description>Common code for 'DyRET'</description>
 	<maintainer email="tonnesfn@ifi.uio.no">tonnesfn</maintainer>
 	<license>GPL-3.0-or-later</license>


### PR DESCRIPTION
This update brings small improvements for `dyret_common`, but since it effects all other packages we release it as a new version.

Downstream packages should not notice this change since it mostly affects `dyret_hardware` and `dyret_simulation` through updates in information coming from `DyRET`.